### PR TITLE
Dockerfile changes to get system running

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,12 +1,13 @@
 # Need a custom image here so that we can incorporate an npm build too
 # Alpine is super light
-FROM alpine:3.13
-
-# Download and install packages
-RUN apk add -U python g++ yarn nodejs npm
+FROM node:13.12.0-alpine
 
 # Work in the membership-portal-ui directory
 WORKDIR /var/www/membership-portal-ui
+COPY membership-portal-ui/package.json ./
+
+# Install Node packages
+RUN yarn
 
 # Start the development server
 CMD ["/bin/sh", "-c", "(node -e 'require(\"node-sass\")' || npm rebuild node-sass) && yarn dev"]


### PR DESCRIPTION
Changed image version to not need to install various packages and run yarn install in the image itself, not on the host system. Together with the PR on the server and on the deployment repo, this should get the dev system up. 