### PR TITLE
Bugfix: Fix leaderboard modal and top users container styling for long names

### DIFF
--- a/src/components/Leaderboard/style.scss
+++ b/src/components/Leaderboard/style.scss
@@ -15,6 +15,8 @@
     margin-top: 20px;
     margin-bottom: 20px;
     min-height: 160px;
+    display: flex;
+    gap: 10px;
 
     .top-user {
       display: inline-block;
@@ -24,13 +26,13 @@
       height: 100%;
 
       &:first-child {
-        padding-left: 5%;
-        margin-right: -5%;
+        padding-left: 0;
+        margin-right: 0;
       }
 
       &:last-child {
-        padding-right: 5%;
-        margin-left: -5%;
+        padding-left: 0;
+        margin-right: 0;
       }
 
       &.top-user-first {
@@ -71,6 +73,8 @@
         font-weight: bold;
         font-size: 1em;
         cursor: pointer;
+        overflow-wrap: break-word;
+        width: 100%;
       }
 
       .name:hover {
@@ -104,18 +108,6 @@
 
         .points {
           font-size: 0.65em;
-        }
-      }
-
-      @media (max-width: 1000px) {
-        &:first-child {
-          padding-left: 0;
-          margin-right: 0;
-        }
-
-        &:last-child {
-          padding-right: 0;
-          margin-left: 0;
         }
       }
     }

--- a/src/components/Modal/leaderboardModal.jsx
+++ b/src/components/Modal/leaderboardModal.jsx
@@ -17,21 +17,20 @@ export default class LeaderboardModal extends React.Component {
         <div className="leaderboard-modal-container">
           <div className="padding">
             <h1>User Info</h1>
-            <br />
-            <br />
+            {/* <br />
+            <br /> */}
             <div className="content-container">
               <div className="image-container">
                 <img src={picture || "/assets/images/unknown.png"} />
               </div>
               <div className="text-container">
-                <h3>
-                  Name: {firstName} {lastName}
-                </h3>
+                <h2>
+                  {firstName} {lastName}
+                </h2>
                 <h3>Major: {major}</h3>
                 <h3>Year: {gradeLevel}</h3>
               </div>
             </div>
-            <br />
             <br />
             <br />
             <div className="button-container">

--- a/src/components/Modal/leaderboardModal.jsx
+++ b/src/components/Modal/leaderboardModal.jsx
@@ -17,8 +17,6 @@ export default class LeaderboardModal extends React.Component {
         <div className="leaderboard-modal-container">
           <div className="padding">
             <h1>User Info</h1>
-            {/* <br />
-            <br /> */}
             <div className="content-container">
               <div className="image-container">
                 <img src={picture || "/assets/images/unknown.png"} />

--- a/src/components/Modal/style.scss
+++ b/src/components/Modal/style.scss
@@ -15,12 +15,10 @@
     background-color: #f0f0f0;
     display: flex;
     flex-direction: column;
-    width: 35%;
-    height: 50%;
     justify-content: flex-start;
     border-radius: 25px;
-    min-height: 480px;
     min-width: 580px;
+    max-width: 700px;
 
     h1 {
       text-align: center;
@@ -33,12 +31,15 @@
         display: flex;
         flex-direction: row;
         justify-content: center;
+        gap: 40px;
+        width: 100%;
 
         .image-container {
           display: flex;
           align-items: center;
           justify-content: center;
-          margin-right: 40px;
+          max-width: 50%;
+          max-height: 100%;
 
           img {
             width: 190px;
@@ -52,13 +53,28 @@
         .text-container {
           display: flex;
           flex-direction: column;
-          margin-left: 40px;
-          align-items: center;
           justify-content: center;
+          overflow-wrap: break-word;
+          gap: 10px;
+          max-width: 50%;
 
           h3 {
-            white-space: pre;
+            margin: 0px;
           }
+        }
+
+        @media (max-width: 700px) {
+          .image-container, .text-container {
+            max-width: 100%;
+          }
+        }
+      }
+
+      @media (max-width: 700px) {
+        .content-container {
+          flex-direction: column; 
+          gap: 10px;
+          text-align: center;
         }
       }
 
@@ -68,6 +84,14 @@
       }
     }
   }
+
+  @media (max-width: 700px) {
+    .leaderboard-modal-container {
+      width: 90%;
+      min-width: 90%;
+      // max-width: 80%;
+    }
+}
 
   .confirmation-modal-container {
     position: relative;


### PR DESCRIPTION
Closes #110 

Changes
* Fixed leaderboard modal to adjust for long names on desktop and mobile viewport 
![image](https://github.com/uclaacm/membership-portal-ui/assets/76643809/5a1d159a-9efc-4052-a532-77dd4929c160)
![image](https://github.com/uclaacm/membership-portal-ui/assets/76643809/cf4f189e-40c4-46d1-a3bf-5d20607fc316)


* Fixed top users container to prevent long names from overlapping
![image](https://github.com/uclaacm/membership-portal-ui/assets/76643809/958f9744-ac54-4572-8bf7-ccc4ebaffebb)
