### PR TITLE
Add RSVP functionality and integrate with events

### DIFF
--- a/src/components/Events/UserEvents/eventCard.jsx
+++ b/src/components/Events/UserEvents/eventCard.jsx
@@ -1,4 +1,6 @@
-import React, {useState, useEffect} from "react";
+import React from "react";
+import { connect } from 'react-redux';
+import { Action } from '../../../reducers';
 import styles from './styles.scss';
 
 /* 
@@ -13,26 +15,98 @@ import styles from './styles.scss';
       title: "",
       startTime: "",
 */
-const EventCard = ({ event }) => {
+class EventCard extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            isRsvped: false,
+            loading: false
+        };
+        this.handleRSVP = this.handleRSVP.bind(this);
+    }
 
-    return (
-        <>
-            <div className="event-container">
-                <div className="image-container">
-                    <div className="cover" style={{backgroundImage: `url(${event.cover})`}}> </div>
-                    <div className="pill-shape points-container">{event.attendancePoints} PTS</div>
-                </div>
+    componentDidMount() {
+        // Fetch RSVPs when component mounts
+        this.props.fetchUserRSVPs();
+    }
 
-                <div className="text-container">
-                    <p className="event-title">{event.title}</p>
-                    <p className="text">{event.startDate?.format("MMMM D, YYYY")}, {event.startDate?.format("h:mm a")}&mdash;{event.endDate?.format("h:mm a")}</p>
-                    <p className="text">{event.location}</p>
-                    <p className="text">{event.committee}</p>
-                    <div className="pill-shape rsvp">RSVP</div>
+    componentDidUpdate(prevProps) {
+        // Check if this event is in the user's RSVPs
+        if (this.props.userRsvps !== prevProps.userRsvps) {
+            this.checkRsvpStatus();
+        }
+    }
+
+    checkRsvpStatus() {
+        const { userRsvps, event } = this.props;
+        if (userRsvps && userRsvps.size > 0) {
+            const hasRsvped = userRsvps.some(rsvp => rsvp.get('event') === event.uuid);
+            this.setState({ isRsvped: hasRsvped });
+        }
+    }
+    
+    async handleRSVP() {
+        this.setState({ loading: true });
+        
+        try {
+            if (this.state.isRsvped) {
+                // Cancel RSVP
+                const result = await this.props.cancelRSVP(this.props.event.uuid);
+                if (result.success) {
+                    this.setState({ isRsvped: false });
+                }
+            } else {
+                // Create RSVP
+                const result = await this.props.createRSVP(this.props.event.uuid);
+                if (result.success) {
+                    this.setState({ isRsvped: true });
+                }
+            }
+        } catch (error) {
+            console.error('RSVP action failed:', error);
+        }
+        
+        this.setState({ loading: false });
+    }
+
+    render() {
+        const { event } = this.props;
+        const { isRsvped, loading } = this.state;
+
+        return (
+            <>
+                <div className="event-container">
+                    <div className="image-container">
+                        <div className="cover" style={{backgroundImage: `url(${event.cover})`}}> </div>
+                        <div className="pill-shape points-container">{event.attendancePoints} PTS</div>
+                    </div>
+
+                    <div className="text-container">
+                        <p className="event-title">{event.title}</p>
+                        <p className="text">{event.startDate?.format("MMMM D, YYYY")}, {event.startDate?.format("h:mm a")}&mdash;{event.endDate?.format("h:mm a")}</p>
+                        <p className="text">{event.location}</p>
+                        <p className="text">{event.committee}</p>
+                        <div 
+                            className={`pill-shape rsvp ${isRsvped ? 'rsvped' : ''} ${loading ? 'loading' : ''}`}
+                            onClick={this.handleRSVP}
+                        >
+                            {loading ? 'Loading...' : isRsvped ? 'Cancel RSVP' : 'RSVP'}
+                        </div>
+                    </div>
                 </div>
-            </div>
-        </>
-    );
+            </>
+        );
+    }
 }
 
-export default EventCard;
+const mapStateToProps = state => ({
+    userRsvps: state.RSVP.get('userRsvps')
+});
+
+const mapDispatchToProps = dispatch => ({
+    fetchUserRSVPs: () => dispatch(Action.FetchUserRSVPs()),
+    createRSVP: (eventUuid) => dispatch(Action.CreateRSVP(eventUuid)),
+    cancelRSVP: (eventUuid) => dispatch(Action.CancelRSVP(eventUuid))
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(EventCard);

--- a/src/components/Events/UserEvents/eventCard.jsx
+++ b/src/components/Events/UserEvents/eventCard.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { connect } from 'react-redux';
 import { Action } from '../../../reducers';
 import styles from './styles.scss';
+import moment from "moment";
 
 /* 
       attendancePoints: "",
@@ -72,7 +73,6 @@ class EventCard extends React.Component {
     render() {
         const { event } = this.props;
         const { isRsvped, loading } = this.state;
-
         return (
             <>
                 <div className="event-container">
@@ -86,6 +86,7 @@ class EventCard extends React.Component {
                         <p className="text">{event.startDate?.format("MMMM D, YYYY")}, {event.startDate?.format("h:mm a")}&mdash;{event.endDate?.format("h:mm a")}</p>
                         <p className="text">{event.location}</p>
                         <p className="text">{event.committee}</p>
+                    
                         <div 
                             className={`pill-shape rsvp ${isRsvped ? 'rsvped' : ''} ${loading ? 'loading' : ''}`}
                             onClick={this.handleRSVP}

--- a/src/components/Events/UserEvents/styles.scss
+++ b/src/components/Events/UserEvents/styles.scss
@@ -40,6 +40,31 @@
   color: white;
   bottom: 0px;
   right: 0px;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+  width: auto;
+  padding: 0 15px;
+
+  &:hover {
+    background-color: darken(rgba(30, 108, 255, 1), 10%);
+  }
+
+  &.rsvped {
+    background-color: #28a745;
+
+    &:hover {
+      background-color: #dc3545;
+    }
+  }
+
+  &.loading {
+    background-color: #6c757d;
+    cursor: not-allowed;
+
+    &:hover {
+      background-color: #6c757d;
+    }
+  }
 }
 
 .text-container {

--- a/src/components/Events/UserEvents/styles.scss
+++ b/src/components/Events/UserEvents/styles.scss
@@ -46,7 +46,7 @@
   padding: 0 15px;
 
   &:hover {
-    background-color: darken(rgba(30, 108, 255, 1), 10%);
+    background-color: rgb(0, 41, 117);
   }
 
   &.rsvped {

--- a/src/config.js
+++ b/src/config.js
@@ -28,6 +28,11 @@ export default {
       fetch: '/api/v1/attendance',
       attend: '/api/v1/attendance/attend',
     },
+    rsvp: {
+      get: '/api/v1/rsvp',
+      create: '/api/v1/rsvp/add',
+      cancel: '/api/v1/rsvp',
+    },
     leaderboard: '/api/v1/leaderboard',
   },
   organization: {

--- a/src/containers/events.js
+++ b/src/containers/events.js
@@ -11,6 +11,7 @@ class Events extends React.Component {
   componentWillMount() {
     if (this.props.authenticated) {
       this.props.fetchEvents();
+      this.props.fetchUserRSVPs();
     }
   }
 
@@ -26,7 +27,7 @@ class Events extends React.Component {
   render() {
     // Only show admin view if user is admin AND adminView is true
     const showAdminView = this.props.isAdmin && this.props.adminView;
-    
+
     return (
       <div>
         <Topbar />
@@ -41,6 +42,10 @@ class Events extends React.Component {
             checkInError={this.props.checkInError}
             checkInPoints={this.props.checkInPoints}
             resetCheckIn={this.props.resetCheckIn}
+            userRsvps={this.props.userRsvps}
+            rsvpError={this.props.rsvpError}
+            createRSVP={this.props.createRSVP}
+            cancelRSVP={this.props.cancelRSVP}
           />
         ) : (
           <AdminEvents
@@ -61,19 +66,21 @@ class Events extends React.Component {
 }
 
 const mapStateToProps = state => ({
-  events: state.Events.get("events"),
-  error: state.Events.get("error"),
-  eventCreated: state.Events.get("posted"),
-  eventCreateSuccess: state.Events.get("postSuccess"),
-  eventUpdated: state.Events.get("updated"),
-  eventUpdateSuccess: state.Events.get("updateSuccess"),
-  authenticated: state.Auth.get("authenticated"),
-  isAdmin: state.Auth.get("isAdmin"),
-  adminView: state.Auth.get("adminView"),
-  checkInSubmitted: state.CheckIn.get("submitted"),
-  checkInPoints: state.CheckIn.get("numPoints"),
-  checkInSuccess: state.CheckIn.get("success"),
-  checkInError: state.CheckIn.get("error"),
+  events: state.Events.get('events'),
+  error: state.Events.get('error'),
+  eventCreated: state.Events.get('posted'),
+  eventCreateSuccess: state.Events.get('postSuccess'),
+  eventUpdated: state.Events.get('updated'),
+  eventUpdateSuccess: state.Events.get('updateSuccess'),
+  authenticated: state.Auth.get('authenticated'),
+  isAdmin: state.Auth.get('isAdmin'),
+  adminView: state.Auth.get('adminView'),
+  checkInSubmitted: state.CheckIn.get('submitted'),
+  checkInPoints: state.CheckIn.get('numPoints'),
+  checkInSuccess: state.CheckIn.get('success'),
+  checkInError: state.CheckIn.get('error'),
+  userRsvps: state.RSVP.get('userRsvps'),
+  rsvpError: state.RSVP.get('error'),
 });
 
 const mapDispatchToProps = dispatch => ({
@@ -103,6 +110,18 @@ const mapDispatchToProps = dispatch => ({
 
   createDone: () => {
     dispatch(Action.CreateEventDone());
+  },
+
+  fetchUserRSVPs: () => {
+    dispatch(Action.FetchUserRSVPs());
+  },
+
+  createRSVP: (eventUuid) => {
+    dispatch(Action.CreateRSVP(eventUuid));
+  },
+
+  cancelRSVP: (eventUuid) => {
+    dispatch(Action.CancelRSVP(eventUuid));
   },
 });
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -5,10 +5,19 @@ import { createBrowserHistory } from 'history';
 import { routerReducer, routerMiddleware } from 'react-router-redux';
 import thunk from 'redux-thunk';
 
-import { User, FetchUser, UpdateUser, UserUpdateDone, FetchActivity } from "./user";
-import { Admins, FetchAdmins, AddAdmin, DeleteAdmin, ChangeSuperAdmin } from "./admins";
-import { Auth, LoginUser, LogoutUser, RefreshToken, ToggleAdminView } from "./auth";
-import { OneClick, ChangeOneClickPassword, ChangeOneClickPasswordDone } from "./oneclick";
+import {
+  User, FetchUser, UpdateUser, UserUpdateDone, FetchActivity,
+} from './user';
+import {
+  Admins, FetchAdmins, AddAdmin, DeleteAdmin, ChangeSuperAdmin,
+} from './admins';
+import {
+  Auth, LoginUser, LogoutUser, RefreshToken, ToggleAdminView,
+} from './auth';
+import { OneClick, ChangeOneClickPassword, ChangeOneClickPasswordDone } from './oneclick';
+import {
+  RSVP, CreateRSVP, CancelRSVP, FetchUserRSVPs,
+} from './rsvp';
 
 import {
   Events,
@@ -34,6 +43,7 @@ const store = createStore(
     Events,
     User,
     Admins,
+    RSVP,
     Leaderboard,
     CheckIn,
     Registration,
@@ -69,6 +79,9 @@ const Action = {
   registerDone,
   CheckInto,
   ResetCheckIn,
+  CreateRSVP,
+  CancelRSVP,
+  FetchUserRSVPs,
 };
 
 export { store, history, Action };

--- a/src/reducers/rsvp.js
+++ b/src/reducers/rsvp.js
@@ -1,0 +1,162 @@
+import Immutable from 'immutable';
+import Config from 'config';
+
+// Action Types
+const RSVP_SUCCESS = Symbol('RSVP_SUCCESS');
+const RSVP_ERROR = Symbol('RSVP_ERROR');
+const CANCEL_RSVP_SUCCESS = Symbol('CANCEL_RSVP_SUCCESS');
+const CANCEL_RSVP_ERROR = Symbol('CANCEL_RSVP_ERROR');
+const FETCH_USER_RSVPS_SUCCESS = Symbol('FETCH_USER_RSVPS_SUCCESS');
+const FETCH_USER_RSVPS_ERROR = Symbol('FETCH_USER_RSVPS_ERROR');
+
+// Initial state
+const State = Immutable.Map({
+  error: '',
+  userRsvps: Immutable.List(),
+  loading: false,
+});
+
+// Action Creators
+class RSVPActions {
+  static RSVP(error, eventUuid) {
+    return {
+      type: error ? RSVP_ERROR : RSVP_SUCCESS,
+      eventUuid,
+      error,
+    };
+  }
+
+  static CancelRSVP(error, eventUuid) {
+    return {
+      type: error ? CANCEL_RSVP_ERROR : CANCEL_RSVP_SUCCESS,
+      eventUuid,
+      error,
+    };
+  }
+
+  static FetchUserRSVPs(error, rsvps) {
+    return {
+      type: error ? FETCH_USER_RSVPS_ERROR : FETCH_USER_RSVPS_SUCCESS,
+      rsvps,
+      error,
+    };
+  }
+}
+
+// Async Actions
+const CreateRSVP = eventUuid => async (dispatch) => {
+  try {
+    const response = await global.fetch(`${Config.API_URL}${Config.routes.rsvp.create}`, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${global.localStorage.getItem('token')}`,
+      },
+      body: JSON.stringify({
+        event: {
+          uuid: eventUuid,
+        },
+      }),
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      throw new Error(data.error || 'Failed to RSVP to event');
+    }
+
+    dispatch(RSVPActions.RSVP(null, eventUuid));
+    return { success: true };
+  } catch (err) {
+    dispatch(RSVPActions.RSVP(err.message || 'Failed to RSVP to event'));
+    return { success: false, error: err };
+  }
+};
+
+const CancelRSVP = eventUuid => async (dispatch) => {
+  try {
+    const response = await global.fetch(`${Config.API_URL}${Config.routes.rsvp.cancel}/${eventUuid}`, {
+      method: 'DELETE',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${global.localStorage.getItem('token')}`,
+      },
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      throw new Error(data.error || 'Failed to cancel RSVP');
+    }
+
+    dispatch(RSVPActions.CancelRSVP(null, eventUuid));
+    return { success: true };
+  } catch (err) {
+    dispatch(RSVPActions.CancelRSVP(err.message || 'Failed to cancel RSVP'));
+    return { success: false, error: err };
+  }
+};
+
+const FetchUserRSVPs = () => async (dispatch) => {
+  try {
+    const response = await global.fetch(Config.API_URL + Config.routes.rsvp.get, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${global.localStorage.getItem('token')}`,
+      },
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      throw new Error(data.error || 'Failed to fetch RSVPs');
+    }
+
+    dispatch(RSVPActions.FetchUserRSVPs(null, data.rsvps));
+    return { success: true, rsvps: data.rsvps };
+  } catch (err) {
+    dispatch(RSVPActions.FetchUserRSVPs(err.message || 'Failed to fetch RSVPs'));
+    return { success: false, error: err };
+  }
+};
+
+// Reducer
+const RSVP = (state = State, action) => {
+  switch (action.type) {
+    case RSVP_SUCCESS:
+      return state.set('error', '');
+
+    case RSVP_ERROR:
+      return state.set('error', action.error);
+
+    case CANCEL_RSVP_SUCCESS:
+      return state.set('error', '');
+
+    case CANCEL_RSVP_ERROR:
+      return state.set('error', action.error);
+
+    case FETCH_USER_RSVPS_SUCCESS:
+      return state
+        .set('error', '')
+        .set('userRsvps', Immutable.fromJS(action.rsvps));
+
+    case FETCH_USER_RSVPS_ERROR:
+      return state
+        .set('error', action.error)
+        .set('userRsvps', Immutable.List());
+
+    default:
+      return state;
+  }
+};
+
+export {
+  RSVP,
+  CreateRSVP,
+  CancelRSVP,
+  FetchUserRSVPs,
+};


### PR DESCRIPTION
## Description

Added RSVP functionality to the events system, allowing users to RSVP to events and cancel their RSVPs. 

- Created a new RSVP reducer with actions for creating, canceling, and fetching RSVPs
- Integrated RSVP functionality into the event card component
- Added RSVP state management to track user RSVPs
- Updated the events container to handle RSVP-related props and actions

Key features:

- Users can RSVP to events with a single click
- Users can cancel their RSVPs
- RSVP status is persisted and synced with the backend
- Loading states are handled during RSVP operations
- Error handling for failed RSVP operations

## Related Issue

Resolves #127

## Steps to view & test changes:
Check the database to see if it updates

- RSVP to an event
- Cancel an RSVP
- Verify RSVP status persists after page refresh
- Check loading states during RSVP operations
- Verify error handling for failed operations

## How Has This Been Tested?


## Screenshots (if appropriate)
<img width="772" alt="image" src="https://github.com/user-attachments/assets/126b3727-dc29-42a7-8fbb-57f279385f9f" />

<img width="835" alt="image" src="https://github.com/user-attachments/assets/9a06c38c-75c6-4c04-b4d2-8b5811227fbb" />

