### PR TITLE
Hydrate home leaderboard widget with live data

### DIFF
--- a/src/components/Events/UserEvents/eventCard.jsx
+++ b/src/components/Events/UserEvents/eventCard.jsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React from 'react';
+import PropTypes from 'prop-types';
 import './style.scss';
 
-/* 
+/*
       attendancePoints: "",
       committee: "",
       cover: "",
@@ -14,25 +15,66 @@ import './style.scss';
       startTime: "",
 */
 const EventCard = ({ event }) => {
+  let formattedStartDate = '';
+  let formattedStartTime = '';
+  if (event.startDate) {
+    formattedStartDate = event.startDate.format('MMMM D, YYYY');
+    formattedStartTime = event.startDate.format('h:mm a');
+  }
 
-    return (
-        <>
-            <div className="event-container">
-                <div className="image-container">
-                    <div className="cover" style={{backgroundImage: `url(${event.cover})`}}> </div>
-                    <div className="pill-shape points-container">{event.attendancePoints} PTS</div>
-                </div>
+  let formattedEndTime = '';
+  if (event.endDate) {
+    formattedEndTime = event.endDate.format('h:mm a');
+  }
 
-                <div className="text-container">
-                    <p className="event-title">{event.title}</p>
-                    <p className="text">{event.startDate?.format("MMMM D, YYYY")}, {event.startDate?.format("h:mm a")}&mdash;{event.endDate?.format("h:mm a")}</p>
-                    <p className="text">{event.location}</p>
-                    <p className="text">{event.committee}</p>
-                    <div className="pill-shape rsvp">RSVP</div>
-                </div>
-            </div>
-        </>
-    );
-}
+  return (
+    <>
+      <div className="event-container">
+        <div className="image-container">
+          <div className="cover" style={{ backgroundImage: `url(${event.cover})` }}> </div>
+          <div className="pill-shape points-container">
+            {event.attendancePoints}
+            {' '}
+            PTS
+          </div>
+        </div>
+
+        <div className="text-container">
+          <p className="event-title">{event.title}</p>
+          <p className="text">
+            {formattedStartDate}
+            ,
+            {' '}
+            {formattedStartTime}
+            &mdash;
+            {formattedEndTime}
+          </p>
+          <p className="text">{event.location}</p>
+          <p className="text">{event.committee}</p>
+          <div className="pill-shape rsvp">RSVP</div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+EventCard.propTypes = {
+  event: PropTypes.shape({
+    attendancePoints: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    committee: PropTypes.string,
+    cover: PropTypes.string,
+    description: PropTypes.string,
+    endDate: PropTypes.shape({
+      format: PropTypes.func.isRequired,
+    }),
+    eventLink: PropTypes.string,
+    location: PropTypes.string,
+    startDate: PropTypes.shape({
+      format: PropTypes.func.isRequired,
+    }),
+    title: PropTypes.string,
+    startTime: PropTypes.string,
+  }).isRequired,
+};
 
 export default EventCard;

--- a/src/components/Home/home.jsx
+++ b/src/components/Home/home.jsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import WelcomeBanner from 'components/Home/WelcomeBanner';
+import PropTypes from 'prop-types';
 import Points from './points';
 
 import './styles.scss';
 import FeaturedEvents from './featuredEvents';
 import EventCard from '../Events/UserEvents/eventCard';
 
+const NUMBER_LEADERBOARD_USERS = 10;
+
 const Home = ({
-  events,
   isAdmin,
   isSuperAdmin,
   adminView,
@@ -18,6 +20,7 @@ const Home = ({
   checkInSuccess,
   checkInError,
   points,
+  leaderboard,
 }) => {
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -60,7 +63,7 @@ const Home = ({
             <>
               <br />
               <span className="CaptionSecondary error">
-                ❌
+                <span role="img" aria-label="cross mark">❌</span>
                 {checkInError}
               </span>
             </>
@@ -69,7 +72,7 @@ const Home = ({
             <>
               <br />
               <span className="CaptionSecondary success">
-                ✅
+                <span role="img" aria-label="check mark">✅</span>
                 {' '}
                 {checkInPoints}
                 {' '}
@@ -86,45 +89,60 @@ const Home = ({
 
         <div className="sidebar-box leaderboard">
           <h3>Leaderboard</h3>
-          <ul>
-            <li>
-              Alex Zheng
-              <span>Pts</span>
-            </li>
-            <li>
-              Smalex
-              <span>Pts</span>
-            </li>
-            <li>
-              Alex is the best
-              <span>Pts</span>
-            </li>
-            <li>
-              Too much time on this
-              <span>Pts</span>
-            </li>
-            <li>
-              RAHHHHHHHH
-              <span>Pts</span>
-            </li>
+          <ul className="leaderboard-list-container">
+            {leaderboard.slice(0, NUMBER_LEADERBOARD_USERS).map((user, index) => (
+              <li key={user.id}>
+                {index + 1}
+                {' '}
+                {user.firstName}
+                {' '}
+                {user.lastName}
+                <span>
+                  {user.points}
+                  {' '}
+                  pts
+                </span>
+              </li>
+            ))}
           </ul>
         </div>
       </aside>
 
       {/* Main Section */}
       <main className="main-section">
-        <WelcomeBanner 
-        isAdmin={isAdmin}
-        isSuperAdmin={isSuperAdmin}
-        adminView={adminView}
-        picture={picture}
-        username={username}
+        <WelcomeBanner
+          isAdmin={isAdmin}
+          isSuperAdmin={isSuperAdmin}
+          adminView={adminView}
+          picture={picture}
+          username={username}
         />
         <FeaturedEvents title="Featured Events" events={eventArray} />
 
       </main>
     </div>
   );
+};
+
+Home.propTypes = {
+  isAdmin: PropTypes.bool.isRequired,
+  isSuperAdmin: PropTypes.bool.isRequired,
+  adminView: PropTypes.bool.isRequired,
+  picture: PropTypes.string.isRequired,
+  username: PropTypes.string.isRequired,
+  checkIn: PropTypes.func.isRequired,
+  checkInPoints: PropTypes.number.isRequired,
+  checkInSuccess: PropTypes.bool.isRequired,
+  checkInError: PropTypes.string.isRequired,
+  points: PropTypes.number.isRequired,
+  leaderboard: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+      firstName: PropTypes.string.isRequired,
+      lastName: PropTypes.string.isRequired,
+      points: PropTypes.number.isRequired,
+    }).isRequired,
+  ).isRequired,
 };
 
 export default Home;

--- a/src/components/Home/home.jsx
+++ b/src/components/Home/home.jsx
@@ -93,7 +93,7 @@ const Home = ({
             {leaderboard.slice(0, NUMBER_LEADERBOARD_USERS).map((user, index) => (
               <li key={user.id}>
                 {index + 1}
-                {' '}
+                {' - '}
                 {user.firstName}
                 {' '}
                 {user.lastName}

--- a/src/components/Home/styles.scss
+++ b/src/components/Home/styles.scss
@@ -164,8 +164,11 @@
 
 /* Expanding Leaderboard */
 .sidebar-custom .leaderboard {
+  display: flex;
+  flex-direction: column;
   flex: 1 1 auto; /* take remaining space */
-  overflow-y: auto; /* scroll if content overflows */
+  height: 400px;
+  padding-bottom: 0;
 }
 
 /* Progress Bar */
@@ -196,6 +199,10 @@
   margin-bottom: 0.5rem;
   display: flex;
   justify-content: space-between;
+}
+.leaderboard-list-container {
+  flex: 1 1 0;
+  overflow-y: scroll;
 }
 
 /* Main Section */
@@ -255,7 +262,7 @@
   font-size: 1.5em;
   font-weight: 700;
   width: 100%;
-  margin-bottom: .5rem;
+  margin-bottom: 0.5rem;
 }
 .events-container {
   display: grid;


### PR DESCRIPTION
The leaderboard widget on the homepage now pulls live leaderboard data in a similar fashion to the Leaderboard page. It can handle an arbitrary number of leaderboard entries by handling overflow with scroll.

## Steps to view & test changes:

1. `git pull` the latest changes.
2. `git checkout home-leaderboard` to switch to this feature branch.
3. `npm i` and start the development server.
4. Log in to the membership portal and navigate to the homepage to see the widget.

## How Has This Been Tested?

- [ ] Manual tests
- [ ] Responsive View

## Screenshots

![image](https://github.com/user-attachments/assets/1c4b3709-e7c1-4ff5-81a3-8c13b2acfed2)