### PR TITLE
Fix scroll-locking on leaderboard and events pages

### DIFF
--- a/src/components/Login/index.jsx
+++ b/src/components/Login/index.jsx
@@ -1,15 +1,8 @@
 import React from 'react';
-import Config from 'config';
 import LoginSidebar from './loginSidebar';
 import Banner from './banner';
 
 export default class LoginComponent extends React.Component {
-  componentDidMount() {
-    // Ensure scrolling is disabled on login page
-    document.body.style.overflow = 'hidden';
-    document.documentElement.style.overflow = 'hidden';
-  }
-
   render() {
     return (
       <div className="login">


### PR DESCRIPTION
## Description

Previously, the Events and Leaderboard pages of the membership portal redesign had scrolling locked on initial login. This issue was no longer present if the user refreshed the page.

I fixed this issue by removing some code that manually set the `html` and `body` tags to `overflow: hidden` on login, which caused the default scrolling behavior to disappear. This was likely intended to prevent scroll on the login page only but persisted afterwards since it was never unset.

## Steps to view & test changes:

1. Switch to the `scroll-locking` branch using `git pull && git checkout scroll-locking`.
2. Deploy the membership portal with `cd ../membership-portal-deployment/dev/ && make`.
3. Log in using UCLA email and observe scrolling behavior on aforementioned pages.

## How Has This Been Tested?

- [ ] Manual tests
- [ ] Responsive View